### PR TITLE
Added UI components to upload model + dataset separately.

### DIFF
--- a/src/pages/designuser/usecases/Create.tsx
+++ b/src/pages/designuser/usecases/Create.tsx
@@ -24,11 +24,13 @@ import {
   DeleteOutlined,
   DownloadOutlined,
   ExperimentOutlined,
+  FileTextOutlined,
   MinusCircleOutlined,
   PlusOutlined,
   QuestionCircleOutlined,
   SaveOutlined,
   SettingOutlined,
+  ThunderboltOutlined,
   UserSwitchOutlined,
 } from '@ant-design/icons';
 import { PageHeaderWrapper } from '@ant-design/pro-layout';
@@ -820,11 +822,15 @@ const Create: React.FC<Params> = (props) => {
                         label="Model File"
                         tooltip={TOOL_TIPS.model_file}
                       >
-                        <input
-                          placeholder="Select .pkl file"
-                          type="file"
-                          onChange={handleFileInputModel}
-                        />
+                        <Space direction="horizontal">
+                          <input
+                            placeholder="Select .h5 or .pkl file"
+                            type="file"
+                            accept=".h5,.pkl"
+                            onChange={handleFileInputModel}
+                          />
+                          <Button type="primary"><ThunderboltOutlined /> Upload Model File</Button>
+                        </Space>
                         {model?.source_file && <Tag color="green">Model Uploaded</Tag>}
                       </Form.Item>
 
@@ -832,11 +838,16 @@ const Create: React.FC<Params> = (props) => {
                         label="Sample Dataset File"
                         tooltip={TOOL_TIPS.model_dataset}
                       >
-                        <input
-                          placeholder="Select .csv file"
-                          type="file"
-                          onChange={handleFileInputData}
-                        />
+                        <Space direction="horizontal">
+                          <input
+                            placeholder="Select .csv or .zip file"
+                            type="file"
+                            accept=".csv,.zip"
+                            onChange={handleFileInputData}
+                            disabled={!modelSource}
+                          />
+                          <Button type="primary" disabled={!modelSource}><FileTextOutlined />Upload Dataset File</Button>
+                        </Space>
                         {model?.dataset_file &&
                           <>
                             <Tag color="green">Dataset Uploaded</Tag>

--- a/src/pages/designuser/usecases/Create.tsx
+++ b/src/pages/designuser/usecases/Create.tsx
@@ -98,6 +98,7 @@ const Create: React.FC<Params> = (props) => {
   const [isModelChanged, setIsModelChanged] = useState(false);
   const [modelData, setModelData] = useState(false);
   const [modelSource, setModelSource] = useState(false);
+  const [modelUploaded, setModelUploaded] = useState<boolean>(false);
 
   const [settingsForm] = Form.useForm();
   const [modelForm] = Form.useForm();
@@ -145,6 +146,14 @@ const Create: React.FC<Params> = (props) => {
 
   }, []);
 
+
+  const handleModelUpload = () => {
+    setModelUploaded(true);
+  }
+
+  const handleDatasetUpload = () => {
+
+  }
 
   // New Persona Popup Functions
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -829,7 +838,12 @@ const Create: React.FC<Params> = (props) => {
                             accept=".h5,.pkl"
                             onChange={handleFileInputModel}
                           />
-                          <Button type="primary"><ThunderboltOutlined /> Upload Model File</Button>
+                          <Button
+                            onClick={handleModelUpload}
+                            type="primary"
+                          >
+                            <ThunderboltOutlined /> Upload Model File
+                          </Button>
                         </Space>
                         {model?.source_file && <Tag color="green">Model Uploaded</Tag>}
                       </Form.Item>
@@ -844,9 +858,15 @@ const Create: React.FC<Params> = (props) => {
                             type="file"
                             accept=".csv,.zip"
                             onChange={handleFileInputData}
-                            disabled={!modelSource}
+                            disabled={!modelUploaded}
                           />
-                          <Button type="primary" disabled={!modelSource}><FileTextOutlined />Upload Dataset File</Button>
+                          <Button
+                            type="primary"
+                            disabled={!modelUploaded}
+                            onClick={handleDatasetUpload}
+                          >
+                            <FileTextOutlined />Upload Dataset File
+                          </Button>
                         </Space>
                         {model?.dataset_file &&
                           <>


### PR DESCRIPTION
- Buttons have been added to allow the upload of model and dataset individually.
- Dataset upload is disabled until model is uploaded.
- Restricted inputs to allow only .h5, .csv, .pkl and .zip files.